### PR TITLE
Remove Elasticsearch baseline since it contains some extremely out-of-date nist tags

### DIFF
--- a/src/assets/data/baselines.json
+++ b/src/assets/data/baselines.json
@@ -269,13 +269,6 @@
       "category": ["Web Servers"]
     },
     {
-      "shortName": "Elasticsearch STIG",
-      "longName": "Elasticsearch STIG",
-      "link": "https://github.com/mitre/elasticsearch-stig-baseline",
-      "svg": "inspec-blue-back-border",
-      "category": ["Application Logic"]
-    },
-    {
       "shortName": "Kubernetes CIS",
       "longName": "Kubernetes CIS",
       "link": "https://github.com/mitre/kubernetes-cis-baseline",


### PR DESCRIPTION


https://github.com/mitre/elasticsearch-stig-baseline/issues/1