### PR TITLE
Updated training page with September 2022 RSVP and updated course info

### DIFF
--- a/src/assets/data/communityData.json
+++ b/src/assets/data/communityData.json
@@ -7,9 +7,10 @@
   "website": "https://saf.mitre.org",
   "programWebsite": "",
   "communityHashTags": ["MTIRESAF", "MITRE_SAF"],
-  "trainingSiteBasic" : "https://mitre-inspec-developer.netlify.com/",
-  "trainingSiteAdvanced" : "https://mitre-inspec-advanced-developer.netlify.app/",
-  "trainingSignUpLink" : "https://forms.office.com/Pages/ResponsePage.aspx?id=SNwgxlAdUkmLOd9NVNdNgkOA91ej9MNHss6_kcyA_29UMFAzTkFSSkFaMVdWRUZFREo5QzBNTkUyRy4u&wdLOR=c0E9A39CC-FF51-4438-80A9-D6EA754AE6A0",
+  "trainingSiteUser": "https://mitre-saf-training.netlify.app/",
+  "trainingSiteBasic" : "https://mitre-saf-training.netlify.app/",
+  "trainingSiteAdvanced" : "https://mitre-saf-training.netlify.app/",
+  "trainingSignUpLink" : "https://forms.office.com/g/BG97DqngPg",
   "trainingContactEmail" : "saf@groups.mitre.org",
   "socialLinks": [
     {

--- a/src/assets/data/trainingData.json
+++ b/src/assets/data/trainingData.json
@@ -2,8 +2,20 @@
   "training": {
     "courses" : [
       {
-        "name" : "Inspec Profile Developer Course",
-        "course_link" : "https://mitre-inspec-developer.netlify.com/",
+        "name" : "SAF User Class (New!)",
+        "course_link" : "https://mitre-saf-training.netlify.app/",
+        "desc" : "This class provides understanding and hands-on practical use of MITRE's Security Automation Framework with a focus on automating security validation and visualization.",
+        "bullets" : [
+          "Identify and locate security guidance for a software component",
+          "Understand the capabilities available in the main pillars of the MITRE Security Automation Framework - Plan, Harden, Validate, Normalize, Visualize",
+          "Visualize InSpec results and third party security tool data",
+          "Define and run an InSpec profile to validate a component against a security guide",
+          "Automatically export checklist results from a security assessment"
+        ]
+      },
+      {
+        "name" : "Inspec Profile Developer Class",
+        "course_link" : "https://mitre-saf-training.netlify.app/",
         "desc" : "This course teaches the basics of writing and running InSpec test profiles. Note that basic knowledge of Ruby and CLI familiarity is required.",
         "video_link" : "https://www.youtube.com/watch?v=KOQbSI6wWUk&list=PLkTApXQou_8LsM26IAZjQsdaDNvsnTWjB&index=1",
         "bullets" : [
@@ -13,14 +25,24 @@
         ]
       },
       {
-        "name" : "Inspec Advanced Developer Course",
-        "course_link" : "https://mitre-inspec-advanced-developer.netlify.app/",
+        "name" : "Inspec Advanced Developer Class",
+        "course_link" : "https://mitre-saf-training.netlify.app/",
         "desc" : "This course provides a deep dive into InSpec's advanced capabilities.",
         "video_link" : "https://www.youtube.com/watch?v=hkd0fbk9efo&list=PLkTApXQou_8LsM26IAZjQsdaDNvsnTWjB&index=3",
         "bullets" : [
           "Learn to use profile inheritance techniques to run multiple profiles against a target",
           "Develop your own InSpec resource objects to cover application stack components",
-          "Expand your test-writing skills to handle more use cases"
+          "Expand your test-writing skills to handle more use cases",
+          "Automate security testing via integration in a CI/CD pipeline"
+        ]
+      },
+      {
+        "name" : "COMING SOON! Security Guidance Developer Class",
+        "desc" : "This course provides a deep dive into InSpec's advanced capabilities.",
+        "bullets" : [
+          "Learn to choose, tailor, and create security guidance appropriate for your mission",
+          "Develop security guidance using the MITRE Vulcan application",
+          "Use Heimdall to review, edit, or export guidance information for security assessment"
         ]
       }
     ]

--- a/src/assets/data/trainingData.json
+++ b/src/assets/data/trainingData.json
@@ -14,7 +14,7 @@
         ]
       },
       {
-        "name" : "Inspec Profile Developer Class",
+        "name" : "Beginner Security Automation Developer Class",
         "course_link" : "https://mitre-saf-training.netlify.app/",
         "desc" : "This course teaches the basics of writing and running InSpec test profiles. Note that basic knowledge of Ruby and CLI familiarity is required.",
         "video_link" : "https://www.youtube.com/watch?v=KOQbSI6wWUk&list=PLkTApXQou_8LsM26IAZjQsdaDNvsnTWjB&index=1",
@@ -25,7 +25,7 @@
         ]
       },
       {
-        "name" : "Inspec Advanced Developer Class",
+        "name" : "Advanced Security Automation Developer Class",
         "course_link" : "https://mitre-saf-training.netlify.app/",
         "desc" : "This course provides a deep dive into InSpec's advanced capabilities.",
         "video_link" : "https://www.youtube.com/watch?v=hkd0fbk9efo&list=PLkTApXQou_8LsM26IAZjQsdaDNvsnTWjB&index=3",

--- a/src/assets/data/trainingData.json
+++ b/src/assets/data/trainingData.json
@@ -38,7 +38,7 @@
       },
       {
         "name" : "COMING SOON! Security Guidance Developer Class",
-        "desc" : "This course provides a deep dive into InSpec's advanced capabilities.",
+        "desc" : "This course looks at MITRE SAF's resources in the planning stage of the security validation process.",
         "bullets" : [
           "Learn to choose, tailor, and create security guidance appropriate for your mission",
           "Develop security guidance using the MITRE Vulcan application",

--- a/src/components/training/RSVPBlock.vue
+++ b/src/components/training/RSVPBlock.vue
@@ -1,33 +1,30 @@
 <template>
   <div>
-    <h2 class="mb-2">RSVP – InSpec profile developer training for May/June 2022!</h2>
+    <h2 class="mb-2">RSVP – SAF training for September 2022!</h2>
     <p >
-      Sponsored by CMS under the
-      <a href="https://saf.cms.gov" target="_blank"
-        >CMS Security Automation Framework</a
-      >, we’re happy to announce plans to again provide training to developers
-      interested in learning to create and maintain InSpec profiles.
+      We’re happy to announce plans to provide training to SAF Users and Developers. 
+      These are free, on-line virtual, hands-on, instructor-led 1-2 day classes.
     </p>
     <p >
-      InSpec profiles are a core tool in establishing tailored, transparent,
-      open-source community-based automated security testing content.
-    </p>
-    <p >
-      These are free, on-line virtual, hands-on, instructor-led 2-day classes.
-    </p>
-    <p >
-      The
+      Sponsored by MDA, the
       <a :href="communityData.trainingSiteBasic" target="_blank"
-        >base introductory InSpec developer class</a
+        >Beginner Security Automation Developer Class</a
       >
-      will again be offered on May 24-25, 2022 (9am-4pm both days) (12 CPE)
+      will again be offered on September 15-16, 2022 (9am-4pm both days) (12 CPE)
     </p>
     <p >
-      The
+      Sponsored by MDA, the
       <a :href="communityData.trainingSiteAdvanced" target="_blank"
-        >follow-on Advanced InSpec developer class</a
+        >follow-on Advanced Security Automation Developer Class</a
       >
-      will again be offered on June 14-15, 2022 (9am-4pm both days) (12 CPE)
+      will again be offered on September 29-30, 2022 (9am-4pm both days) (12 CPE)
+    </p>
+    <p >
+      Sponsored by DSCA, the new, 
+      <a :href="communityData.trainingSiteUser" target="_blank"
+        >SAF User Class</a
+      >
+      will be offered on September 27, 2022 (9am-4pm) (6 CPE)
     </p>
     <p >
       Please RSVP if you are interested in attending or have additional
@@ -49,7 +46,7 @@
       >RSVP!</v-btn
     >
     <p >
-      A note on prerequisites: For the basic class, knowledge of basic
+      A note on prerequisites: For the Beginner Security Automation Developer Class, knowledge of basic
       programming concepts, modern language conventions and some working
       experience with a modern language (e.g., Ruby, Python, Go, etc) is useful.
       (Inspec is a Ruby Domain-specific language (DSL)). To become more familiar

--- a/src/components/training/traininginfo.vue
+++ b/src/components/training/traininginfo.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid>
-    <!-- <RSVPBlock class="mt-2" /> -->
+    <RSVPBlock class="mt-2" />
     <v-row
       align="center"
       justify="center"
@@ -42,7 +42,7 @@
   import communityData from "@/assets/data/communityData.json";
   import trainingData from "@/assets/data/trainingData.json";
   import resources from "@/assets/data/resources.json";
-  // import RSVPBlock from "@/components/training/RSVPBlock.vue";
+  import RSVPBlock from "@/components/training/RSVPBlock.vue";
   export default {
     name: "App",
     data: () => ({
@@ -66,7 +66,7 @@
       // },
     },
     components: {
-      // RSVPBlock,
+      RSVPBlock,
     },
     methods: {
       passItemData(item) {

--- a/src/views/Training.vue
+++ b/src/views/Training.vue
@@ -5,10 +5,9 @@
         <Header>
           <h3 slot="title">Our Training</h3>
           <div class="mt-2" slot="subtitle">
-            The MITRE SAF team regularly offers training courses for developing
-            automated validation tests using InSpec. Dates and sign-up links for
+            The MITRE SAF team regularly offers training courses. Dates and sign-up links for
             future courses are posted on this page when training dates are
-            finalized. See below for course materials and recordings.
+            finalized. See below for course details, materials, and recordings.
           </div>
         </Header>
       </v-col>


### PR DESCRIPTION
- Added September 2022 RSVP link and information
- Added SAF User Class new information
- Added a "Coming Soon" for a preview of a security guidance developer class to come (Vulcan class)
- Updated links to reference the saf-training site where all class content will be hosted
- Minor other edits to generalize from "InSpec training" to general "SAF training"

Check out the "Training" page on the netlify preview for ease of review.

Signed-off-by: Emily Rodriguez <ecrodriguez@mm279976-pc.lan>