### PR TITLE
Lock control data table ingestion to node 14

### DIFF
--- a/.github/workflows/control-table-data-ingestion.yml
+++ b/.github/workflows/control-table-data-ingestion.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Pull down this repo
         uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
       - name: Ingest and process data
         uses: docker://mitre/saf-baseline-ingestion
       - name: Commit processed data


### PR DESCRIPTION
I believe Github Actions upgraded the version of node that is running and thus broke this job. I can't test it but I believe this will fix it.

More info: https://stackoverflow.com/questions/67330252/thread-id-key-0x7777-function-find-thread-id-key-file-src-coroutine-cc